### PR TITLE
build: convert celery class Task to @shared_task

### DIFF
--- a/rest_hooks/tasks.py
+++ b/rest_hooks/tasks.py
@@ -1,35 +1,35 @@
 import requests
 import json
 
-from celery.task import Task
+from celery import shared_task
 
 from django.core.serializers.json import DjangoJSONEncoder
 
 from rest_hooks.utils import get_hook_model
 
 
-class DeliverHook(Task):
-    def run(self, target, payload, instance=None, hook_id=None, **kwargs):
-        """
-        target:     the url to receive the payload.
-        payload:    a python primitive data structure
-        instance:   a possibly null "trigger" instance
-        hook:       the defining Hook object (useful for removing)
-        """
-        response = requests.post(
-            url=target,
-            data=json.dumps(payload, cls=DjangoJSONEncoder),
-            headers={'Content-Type': 'application/json'}
-        )
+@shared_task
+def deliver_hook(target, payload, instance=None, hook_id=None, **kwargs):
+    """
+    target:     the url to receive the payload.
+    payload:    a python primitive data structure
+    instance:   a possibly null "trigger" instance
+    hook:       the defining Hook object (useful for removing)
+    """
+    response = requests.post(
+        url=target,
+        data=json.dumps(payload, cls=DjangoJSONEncoder),
+        headers={'Content-Type': 'application/json'}
+    )
 
-        if response.status_code == 410 and hook_id:
-            HookModel = get_hook_model()
-            hook = HookModel.object.get(id=hook_id)
-            hook.delete()
+    if response.status_code == 410 and hook_id:
+        HookModel = get_hook_model()
+        hook = HookModel.object.get(id=hook_id)
+        hook.delete()
 
-        # would be nice to log this, at least for a little while...
+    # would be nice to log this, at least for a little while...
 
 def deliver_hook_wrapper(target, payload, instance=None, hook=None, **kwargs):
     if hook:
         kwargs['hook_id'] = hook.id
-    return DeliverHook.delay(target, payload, **kwargs)
+    return deliver_hook.delay(target, payload, **kwargs)


### PR DESCRIPTION
This change converts from legacy Class based task to decorator task. This is for upgrading from 4.x Celery to 5.2.7.